### PR TITLE
HASTUS Changes for Eliza + Run Identifier

### DIFF
--- a/HASTUS_Converter.py
+++ b/HASTUS_Converter.py
@@ -217,56 +217,37 @@ def TTS_H(path, mypath = None):
             loID       = oID + otrack
             ldID       = dID + dtrack
             
-            
-            if '-' not in run:
-                if (run[0] == "E" and run[1].isnumeric()):
-                    if run[-1] == 'A':
-                        run_ = 'E'
-                        for x in run[1:]:
-                            if x.isnumeric():
-                                run_ += x
-                        run_ += '-'   
-                        for x in run[1:]:
-                            if x.isalpha():
-                                run_ += x
-                        run = run_
-                        
-                elif (len(run) >= 3 and run[2] == "E" and run[0].isnumeric()):
-                    run_ = ''
-                    if run[-1] == 'A':
-                        
-                        for x in run[0:]:
-                            if x.isnumeric():
-                                run_ += x
-                        run_ += 'E'
-                        run_ += '-'   
-                        for x in run[3:]:
-                            if x.isalpha():
-                                run_ += x
-                        run = run_
-                    
-                elif (run[0].isalpha() and run[-1] == '1'):
-                    run_ = ''
-                    for x in run:
-                        if x.isalpha():
-                            run_ += x
-                    run_ += '-'   
-                    for x in run:
-                        if x.isnumeric():
-                            run_ += x
-                    run = run_
-                    
-                elif (run[0].isnumeric() and run[-1] == 'A'):
-                    run_ = ''
-                    for x in run:
-                        if x.isnumeric():
-                            run_ += x
-                    run_ += '-'   
-                    for x in run:
-                        if x.isalpha():
-                            run_ += x
-                    run = run_
-                    
+            def format_run(run):
+                if '-' in run:
+                    return run
+    
+                newrun = ''
+                # ETCS case for E12A, E12B runs to become E12-A, E12-B runs - and for regular E12 runs
+                if run.startswith("E") and run[1].isnumeric():
+                    digits = ''.join(x for x in run[1:] if x.isnumeric())
+                    letters = ''.join(x for x in run[1:] if x.isalpha())
+                    newrun = f"E{digits}-{letters}" if run.endswith(('A','B')) else f"E{digits}"
+                
+                # ETCS case for 34EA, 34EB runs to become 34E-A, 34E-B runs - and for regular 34E runs
+                elif len(run) >= 3 and run[0].isnumeric() and run[2] == "E":
+                    digits = ''.join(x for x in run if x.isnumeric())
+                    letters = ''.join(x for x in run[3:] if x.isalpha())
+                    newrun = f"{digits}E-{letters}" if run.endswith(('A','B')) else f"{digits}E"
+                
+                # Case for 12A, 12B runs to become 12-A, 12-B runs
+                elif run[0].isnumeric() and run.endswith(('A','B')):
+                    digits = ''.join(x for x in run if x.isnumeric())
+                    letters = ''.join(x for x in run if x.isalpha())
+                    newrun = f"{digits}-{letters}"
+                
+                # Case for AB1, AB2 runs to become AB-1, AB-2 runs
+                elif run[0].isalpha() and run.endswith(('1','2')):
+                    letters = ''.join(x for x in run if x.isalpha())
+                    digits = ''.join(x for x in run if x.isnumeric())
+                    newrun = f"{letters}-{digits}"
+    
+                return newrun if newrun else run
+            run = format_run(run)
             
             if WeekdayKey not in d_list:
                 d_list.append(WeekdayKey)


### PR DESCRIPTION
This request in full will update our HASTUS Converter so that:
- Clapham Stabling (CPM_S) is only referenced when a train is actually stabling - otherwise uses CPM1/2
- WUL_S node is no longer used - we now use WFE_S and WFW_S for East and West Wulkuraka Stabling
- - - Similarly, FEE is no longer referred to as WFE_S as this creates issues downstream. Now uses FEE2 and FWE1 for East and West Wulkuraka Entrance
- Added and commented out a piece of code (not a very good one) which would allow for the case if HYBRID units were introduced to represent NGR's. Could be useful for The Games timetable if we use hybrids like the Commonwealth games. 
- Run ID identifier has been updated to account for ETCS units and made more streamline - will be transferring to other ETCS-enabled scripts